### PR TITLE
Initialize DB during tests

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -15,6 +15,7 @@ from models.section import Section
 from models.student import Student
 from models.survey import Survey
 from models.user import User
+from models.response import Response
 from tornado import ioloop, gen
 from tornado.concurrent import Future, chain_future
 from tornado.options import define, options
@@ -49,6 +50,7 @@ def initialize_db():
     Student().init(connection)
     Survey().init(connection)
     User().init(connection)
+    Response().init(connection)
 
 if __name__ == "__main__":
     main()

--- a/src/setup.py
+++ b/src/setup.py
@@ -3,9 +3,11 @@ import json
 from models.user import User
 from models.survey import Survey
 from config.config import application
+from server import initialize_db
 
 class Setup:
     def init_data(self):
+        initialize_db()
         with open('../schema/sampleSurvey.json', 'r') as f:
            data = json.loads(f.read())
            Survey().create_item(data)


### PR DESCRIPTION
This fixes a bug where the database and tables would not be created on `make test`. It also fixes a bug where the Response table was not created.
