### PR TITLE
Last minute fix for tying backend data with frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ bootstrap_data:
 	@read -p 'Enter User ID to boostrap (include surrounding quotes):' x; \
 	cd src && python3 -c 'from server import bootstrap_data; bootstrap_data('$$x')'
 
+wipe_user_data:
+	@read -p 'Enter User ID to wipe (include surrounding quotes):' x; \
+	cd src && python3 -c 'from server import wipe_data; wipe_data('$$x')'
+
 build:
 	pip3 install -r requirements.txt
 	npm install

--- a/src/handlers/dashboard_handler.py
+++ b/src/handlers/dashboard_handler.py
@@ -12,9 +12,12 @@ class DashboardHandler(BaseHandler):
     def get_survey_json(self):
         survey_json = []
         user_data = self.current_user
+        print(user_data)
         unanswered_survey_ids = user_data['unanswered_surveys']
         for survey_id in unanswered_survey_ids:
             survey_data = Survey().decompose(survey_id)
+            if survey_data is None:
+                continue
             survey_json.append(survey_data)
         print(tornado.escape.json_encode(survey_json))
         return tornado.escape.json_encode(survey_json)

--- a/src/models/question.py
+++ b/src/models/question.py
@@ -24,7 +24,7 @@ class Question(BaseModel):
     def default(self):
         return {
             'title' : "",
-            'response_format' : ""
+            'response_format' : "",
             'options' : []
         }
 

--- a/src/models/question.py
+++ b/src/models/question.py
@@ -3,7 +3,12 @@ import random
 import services.lorem_ipsum as lorem_ipsum
 class Question(BaseModel):
 
-    USER_RESPONSE_FORMAT = ['Free reponse', 'Mutiple choice', 'Dichotomous', 'Rank order scaling', 'Rating scale']
+    RESPONSE_FREE = 'freeReponse'
+    RESPONSE_MULTIPLE_CHOICE = 'mutipleChoice'
+    RESPONSE_TRUE_OR_FALSE = 'trueOrFalse'
+    RESPONSE_RATING = 'rating'
+
+    USER_RESPONSE_FORMAT = [RESPONSE_FREE, RESPONSE_MULTIPLE_CHOICE, RESPONSE_TRUE_OR_FALSE, RESPONSE_RATING]
 
     def requiredFields(self):
         return ['text', 'response_format']
@@ -11,18 +16,29 @@ class Question(BaseModel):
     def fields(self):
         b = super(__class__, self)
         return {
-            'text' : (b.is_string, b.is_not_empty, ),
-            'response_format' : (b.is_string, b.is_in_list(self.USER_RESPONSE_FORMAT))
+            'title' : (b.is_string, b.is_not_empty, ),
+            'response_format' : (b.is_string, b.is_in_list(self.USER_RESPONSE_FORMAT)),
+            'options' : (b.is_list,)
         }
 
     def default(self):
         return {
-            'text' : "",
+            'title' : "",
             'response_format' : ""
+            'options' : []
         }
+
+    def create_generic_options(self, response_format):
+        if response_format == RESPONSE_TRUE_OR_FALSE:
+            return ['yes', 'no']
+        if response_format == RESPONSE_MULTIPLE_CHOICE:
+            return ['alpha','beta','gamma','delta']
+        return []
+
 
     def create_generic_item(self):
         data = self.default()
-        data['text'] = lorem_ipsum.lorem_ipsum()
+        data['title'] = lorem_ipsum.lorem_ipsum()
         data['response_format'] = random.choice(self.USER_RESPONSE_FORMAT)
+        data['options'] = self.create_generic_options(data['response_format'])
         return super(Question, self).create_item(data)

--- a/src/models/survey.py
+++ b/src/models/survey.py
@@ -38,7 +38,6 @@ class Survey(BaseModel):
             self.send_user_survey(subscriber_id, survey_id)
         return survey_id
 
-
     # returns default survey data, that can be overwritten. Good for templating a new user
     def default(self):
         return {
@@ -59,6 +58,8 @@ class Survey(BaseModel):
 
     def decompose(self, survey_id):
         survey_data = self.get_item(survey_id)
+        if survey_data is None:
+            return None
         decomposed_data = survey_data.copy()
         decomposed_question_data = []
         question_ids = survey_data['questions']

--- a/src/server.py
+++ b/src/server.py
@@ -83,7 +83,9 @@ def wipe_data(user_id):
     user_data['courses'] = []
     user_data['created_surveys'] = []
     user_data['unanswered_surveys'] = []
-    User().update_item(user_id)
+    update_response = User().update_item(user_id, user_data)
+    print(update_response)
+    return
 
 if __name__ == "__main__":
     main()

--- a/src/server.py
+++ b/src/server.py
@@ -69,5 +69,21 @@ def bootstrap_data(user_id):
     print('survey id:\n'+survey_id)
     return
 
+def wipe_data(user_id):
+    """
+    Wipes the data associated with a users surveys, classes and courses
+    Warning: Does not disassociate surveys with courses, user with courses, etc.
+    It just makes a user fresh and ready for new data
+    """
+    initialize_db()
+    user_data = User().get_item(user_id)
+    if user_data is None:
+        print("user_id {0} does not correspond to a valid user in the database!".format(user_id))
+        return
+    user_data['courses'] = []
+    user_data['created_surveys'] = []
+    user_data['unanswered_surveys'] = []
+    User().update_item(user_id)
+
 if __name__ == "__main__":
     main()

--- a/src/services/culdapauth.py
+++ b/src/services/culdapauth.py
@@ -65,8 +65,12 @@ def user_info_ldap(uname, attributes=None):
         logging.error("Username not supplied")
         return False
     server = ldap.Server(LDAP_URL, get_info=ldap.ALL)
-    conn = ldap.Connection(server, auto_bind=True)
-    conn.start_tls()
+    conn = None
+    try:
+        conn = ldap.Connection(server, auto_bind=True)
+        conn.start_tls()
+    except:
+        return False
     udn = conn.search(LDAP_SEARCH_BASE, '(%s=%s)' % (LDAP_UNAME_ATTR,uname), search_scope=LDAP_SEARCH_SCOPE, attributes=attributes)
     resp = conn.response
     if udn:


### PR DESCRIPTION
- adds a makefile endpoint `make wipe_user_data` to wipe a user of any associated courses and surveys. This is useful for a number of reasons
- minor exception catch for when cu's ldap server is down (!!!)
- changes to question models so they conform to react constants
- survey decomposition skips nonexistent surveys
