### PR TITLE
Cleanup/code styles, BaseModel tests

### DIFF
--- a/src/handlers/login_handler.py
+++ b/src/handlers/login_handler.py
@@ -13,7 +13,7 @@ class LoginHandler(BaseHandler):
     def post(self):
         username = self.get_argument('username',strip = True)
         password = self.get_argument('password',strip = True)
-        cursor = User().find({'username' : username})
+        cursor = User().find_item({'username' : username})
         for user_data in cursor:
             user_id = user_data['id']
             if User().authenticate(user_id, password):

--- a/src/handlers/register_handler.py
+++ b/src/handlers/register_handler.py
@@ -43,4 +43,4 @@ class RegisterHandler(BaseHandler):
         )
 
     def getLdapUser(self, username, registration):
-        return User().find({'username' : username, 'registration' : registration})
+        return User().find_item({'username' : username, 'registration' : registration})

--- a/src/handlers/survey_handler.py
+++ b/src/handlers/survey_handler.py
@@ -32,5 +32,5 @@ class SurveyHandler(BaseHandler):
         else:
             courses = user_data['courses']
             for course in courses:
-                data += models.survey.Survey().find({'course': course, })
+                data += models.survey.Survey().find_item({'course': course, })
         self.write(json.dumps(data))

--- a/src/handlers/survey_handler.py
+++ b/src/handlers/survey_handler.py
@@ -8,11 +8,13 @@ from models.user import User
 import models.answer
 from handlers.base_handler import BaseHandler
 
+
 class Responses(BaseHandler):
     def post(self):
         body = self.request.body.decode("utf-8")
         data = json.loads(body)
         Response().create_item(data)
+
 
 class Surveys(BaseHandler):
     def post(self):
@@ -27,5 +29,5 @@ class Surveys(BaseHandler):
         else:
             courses = user_data['courses']
             for course in courses:
-                data += models.survey.Survey().find({'course': course,})
+                data += models.survey.Survey().find({'course': course, })
         self.write(json.dumps(data))

--- a/src/models/answer.py
+++ b/src/models/answer.py
@@ -1,5 +1,6 @@
 from models.basemodel import BaseModel
 
+
 class Answer(BaseModel):
     # Dichotomous: two possible responses (i.e. yes or no)
     # Rank order scaling: Among the choices given, rank them in order
@@ -12,10 +13,10 @@ class Answer(BaseModel):
     def fields(self):
         b = super(Answer, self)
         return {
-            'user_id' : (b.is_int, ),
-            'survey_id' : (b.is_int, ),
-            'question_id' : (b.is_int, ),
-            'response_format' : (b.is_string, is_reponse_format,)
+            'user_id': (b.is_int, ),
+            'survey_id': (b.is_int, ),
+            'question_id': (b.is_int, ),
+            'response_format': (b.is_string, is_reponse_format,)
         }
 
     def is_reponse_format(self, data):

--- a/src/models/basemodel.py
+++ b/src/models/basemodel.py
@@ -44,7 +44,7 @@ class BaseModel:
 
     def is_unique(self, data, key):
         def _unique(data):
-            assert len(self.find({key: data})) == 0, "data '{0}' Must must be a unique value in the database with respect to key {1}".format(data, key)
+            assert len(self.find_item({key: data})) == 0, "data '{0}' Must must be a unique value in the database with respect to key {1}".format(data, key)
         return _unique
 
     def is_none(self, data):
@@ -109,10 +109,19 @@ class BaseModel:
             pass
 
     def get_item(self, idnum):
+        """
+        Given an id number number of an item in the database, retrieve the data
+        the idnum corresponds to in the database
+        """
         table = self.__class__.__name__
         return r.db(BaseModel.DB).table(table).get(idnum).run(BaseModel.conn)
 
     def update_item(self, idnum, data):
+        """
+        Given an id number number of an item in the database and a data hash,
+        update the fields of the data in the database with the fields in the
+        data hash
+        """
         table = self.__class__.__name__
         return r.db(BaseModel.DB).table(table).get(idnum).update(data).run(BaseModel.conn)
 
@@ -163,9 +172,11 @@ class BaseModel:
         user_survey_list.append(survey_id)
         return r.db(BaseModel.DB).table(user_table).get(user_id).update({survey_key: user_survey_list}).run(BaseModel.conn)
 
-    def find(self, key):
+    def find_item(self, data):
+        """
+        """
         table = self.__class__.__name__
-        return list(r.db(BaseModel.DB).table(table).filter(key).run(BaseModel.conn))
+        return list(r.db(BaseModel.DB).table(table).filter(data).run(BaseModel.conn))
 
     # create a new database item from given data, if the data passes the validator
     def create_item(self, data):

--- a/src/models/course.py
+++ b/src/models/course.py
@@ -1,6 +1,7 @@
 from models.basemodel import BaseModel
 import random
 
+
 class Course(BaseModel):
 
     def requiredFields(self):
@@ -9,25 +10,25 @@ class Course(BaseModel):
     def fields(self):
         b = super(Course, self)
         return {
-            'course_name' : (b.is_string, b.is_not_empty,),
-            'department' : (b.is_string, ),
-            'average_grade' : (b.is_int, ),
-            'credit_hours' : (b.is_int, ),
-            'active_surveys' : (b.is_list, ),
-            'inactive_surveys' : (b.is_list,),
-            'subscribers' : (b.is_list,),
+            'course_name': (b.is_string, b.is_not_empty,),
+            'department': (b.is_string, ),
+            'average_grade': (b.is_int, ),
+            'credit_hours': (b.is_int, ),
+            'active_surveys': (b.is_list, ),
+            'inactive_surveys': (b.is_list,),
+            'subscribers': (b.is_list,),
         }
 
     # returns default survey data, that can be overwritten. Good for templating a new user
     def default(self):
         return {
-            'course_name' : "",
-            'department' : "",
-            'average_grade' : 0,
-            'credit_hours' : 0,
-            'active_surveys' : [],
-            'inactive_surveys' : [],
-            'subscribers' : []
+            'course_name': "",
+            'department': "",
+            'average_grade': 0,
+            'credit_hours': 0,
+            'active_surveys': [],
+            'inactive_surveys': [],
+            'subscribers': []
         }
 
     def subscribe_user(self, user_id, course_id):

--- a/src/models/instructor.py
+++ b/src/models/instructor.py
@@ -1,5 +1,6 @@
 from models.basemodel import BaseModel
 
+
 class Instructor(BaseModel):
 
     def requiredFields(self):
@@ -8,8 +9,8 @@ class Instructor(BaseModel):
     def fields(self):
         b = super(Instructor, self)
         return {
-            'instructor_name' : (b.is_string, ),
-            'department' : (b.is_string, ),
-            'college' : (b.is_string, ),
-            'section' : (b.is_string, )
+            'instructor_name': (b.is_string, ),
+            'department': (b.is_string, ),
+            'college': (b.is_string, ),
+            'section': (b.is_string, )
         }

--- a/src/models/question.py
+++ b/src/models/question.py
@@ -1,6 +1,8 @@
 from models.basemodel import BaseModel
 import random
 import services.lorem_ipsum as lorem_ipsum
+
+
 class Question(BaseModel):
 
     RESPONSE_FREE = 'freeReponse'
@@ -16,25 +18,24 @@ class Question(BaseModel):
     def fields(self):
         b = super(__class__, self)
         return {
-            'title' : (b.is_string, b.is_not_empty, ),
-            'response_format' : (b.is_string, b.is_in_list(self.USER_RESPONSE_FORMAT)),
-            'options' : (b.is_list,)
+            'title': (b.is_string, b.is_not_empty, ),
+            'response_format': (b.is_string, b.is_in_list(self.USER_RESPONSE_FORMAT)),
+            'options': (b.is_list,)
         }
 
     def default(self):
         return {
-            'title' : "",
-            'response_format' : "",
-            'options' : []
+            'title': "",
+            'response_format': "",
+            'options': []
         }
 
     def create_generic_options(self, response_format):
         if response_format == self.RESPONSE_TRUE_OR_FALSE:
             return ['yes', 'no']
         if response_format == self.RESPONSE_MULTIPLE_CHOICE:
-            return ['alpha','beta','gamma','delta']
+            return ['alpha', 'beta', 'gamma', 'delta']
         return []
-
 
     def create_generic_item(self):
         data = self.default()

--- a/src/models/response.py
+++ b/src/models/response.py
@@ -1,5 +1,6 @@
 from models.basemodel import BaseModel
 
+
 class Response(BaseModel):
     def requiredFields(self):
         return ['user_id', 'survey_id', 'answer_id']
@@ -7,7 +8,7 @@ class Response(BaseModel):
     def fields(self):
         b = super(Response, self)
         return {
-            'user_id' : (b.is_int, ),
-            'survey_id' : (b.is_int, ),
-            'answer_id' : (b.is_int, )
+            'user_id': (b.is_int, ),
+            'survey_id': (b.is_int, ),
+            'answer_id': (b.is_int, )
         }

--- a/src/models/section.py
+++ b/src/models/section.py
@@ -1,6 +1,10 @@
 from models.basemodel import BaseModel
 
+
 class Section(BaseModel):
+    """
+    A section is an individual instance of an offered course.
+    """
 
     def requiredFields(self):
         return ['course_id', 'course_name', 'average_grade', 'credit_hours', 'section_time', 'instructor_id']
@@ -8,10 +12,10 @@ class Section(BaseModel):
     def fields(self):
         b = super(Section, self)
         return {
-            'course_id' : (b.is_int, ),
-            'course_name' : (b.is_string, ),
-            'average_grade' : (b.is_int, ),
-            'credit_hours' : (b.is_int, ),
-            'section_time' : (b.is_date_string, ),
-            'instructor_id' : (b.is_int, )
+            'course_id': (b.is_int, ),
+            'course_name': (b.is_string, ),
+            'average_grade': (b.is_int, ),
+            'credit_hours': (b.is_int, ),
+            'section_time': (b.is_timestamp, ),
+            'instructor_id': (b.is_int, )
         }

--- a/src/models/student.py
+++ b/src/models/student.py
@@ -1,5 +1,6 @@
 from models.basemodel import BaseModel
 
+
 class Student(BaseModel):
     COLLEGE_ARTS_AND_SCIENCES = 'College of Arts and Sciences'
     COLLEGE_ENGINEERING = 'College of Engineering and Applied Science'
@@ -27,10 +28,10 @@ class Student(BaseModel):
     def fields(self):
         b = super(Student, self)
         return {
-            'college' : (b.is_in_list(COLLEGES), ),
-            'majors' : (b.is_list, schema_list_check(b.is_major),),
-            'minors' : (b.is_list, schema_list_check(b.is_minor),),
-            'gpa' : (b.is_int, ),
-            'course_history' : (b.is_list, ),
-            'credits_earned' : (b.is_int, )
+            'college': (b.is_in_list(COLLEGES), ),
+            'majors': (b.is_list, schema_list_check(b.is_major),),
+            'minors': (b.is_list, schema_list_check(b.is_minor),),
+            'gpa': (b.is_int, ),
+            'course_history': (b.is_list, ),
+            'credits_earned': (b.is_int, )
         }

--- a/src/models/survey.py
+++ b/src/models/survey.py
@@ -4,6 +4,7 @@ from models.user import User
 from models.question import Question
 import random
 
+
 class Survey(BaseModel):
 
     def requiredFields(self):
@@ -12,13 +13,13 @@ class Survey(BaseModel):
     def fields(self):
         b = super(Survey, self)
         return {
-            'questions' : (b.is_list, ),
-            'survey_id' : (b.is_string, b.is_not_empty,),
-            'questions' : (b.is_list, self.schema_list_check(b.is_string)),
-            'course_id' : (b.is_string, b.is_not_empty,),
-            'course_name' : (b.is_string, b.is_not_empty,),
-            'creator_id' : (b.is_string, b.is_not_empty,),
-            'creator_name' : (b.is_string, b.is_not_empty,)
+            'questions': (b.is_list, ),
+            'survey_id': (b.is_string, b.is_not_empty,),
+            'questions': (b.is_list, self.schema_list_check(b.is_string)),
+            'course_id': (b.is_string, b.is_not_empty,),
+            'course_name': (b.is_string, b.is_not_empty,),
+            'creator_id': (b.is_string, b.is_not_empty,),
+            'creator_name': (b.is_string, b.is_not_empty,)
         }
 
     def create_item(self, data):
@@ -32,7 +33,7 @@ class Survey(BaseModel):
         active_surveys = course_data['active_surveys']
         active_surveys.append(survey_id)
         subscribers = course_data['subscribers']
-        Course().update_item(course_id, {'active_surveys' : active_surveys })
+        Course().update_item(course_id, {'active_surveys': active_surveys})
         self.send_user_survey(creator_id, survey_id, 'created_surveys')
         for subscriber_id in subscribers:
             self.send_user_survey(subscriber_id, survey_id)
@@ -41,11 +42,11 @@ class Survey(BaseModel):
     # returns default survey data, that can be overwritten. Good for templating a new user
     def default(self):
         return {
-            'questions' : [],
-            'course_id' : "",
-            'creator_id' : "",
-            'course_name' : "",
-            'creator_name' : ""
+            'questions': [],
+            'course_id': "",
+            'creator_id': "",
+            'course_name': "",
+            'creator_name': ""
         }
 
     def create_generic_item(self, creator_id, course_id=None):

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -4,72 +4,76 @@ import time
 import services.culdapauth as culdapauth
 from models.basemodel import BaseModel
 
+
 class User(BaseModel):
-    TESTING_PASSWORD        = 't3sT1ng U$er P4ssw0rd'
-    REGISTRATION_TESTING    = 'registration_testing'
-    REGISTRATION_CULDAP     = 'registration_culdap'
-    REGISTRATION_METHODS    = [REGISTRATION_TESTING, REGISTRATION_CULDAP]
-    NO_DISCLOSURE           = 'Prefer Not to Disclose'
-    USER_GENDERS            = ['Male', 'Female', 'Other', NO_DISCLOSURE]
-    USER_ETHNICITIES        = ['American Indian or Alaska Native', 'Asian', 'Black or African American', 'Hispanic or Latino', 'Native Hawaiian or Other Pacific Islander', 'White', 'Other', NO_DISCLOSURE]
-    USER_NATIVE_LANGUAGES   = ['English', 'Spanish', 'French', 'German', 'Korean', 'Chinese', 'Japanese', 'Russian', 'Arabic', 'Portuguese', 'Hindi', 'Other', NO_DISCLOSURE]
+    TESTING_PASSWORD = 't3sT1ng U$er P4ssw0rd'
+    REGISTRATION_TESTING = 'registration_testing'
+    REGISTRATION_CULDAP = 'registration_culdap'
+    REGISTRATION_METHODS = [REGISTRATION_TESTING, REGISTRATION_CULDAP]
+    NO_DISCLOSURE = 'Prefer Not to Disclose'
+    USER_GENDERS = ['Male', 'Female', 'Other', NO_DISCLOSURE]
+    USER_ETHNICITIES = ['American Indian or Alaska Native', 'Asian', 'Black or African American', 'Hispanic or Latino', 'Native Hawaiian or Other Pacific Islander', 'White', 'Other', NO_DISCLOSURE]
+    USER_NATIVE_LANGUAGES = ['English', 'Spanish', 'French', 'German', 'Korean', 'Chinese', 'Japanese', 'Russian', 'Arabic', 'Portuguese', 'Hindi', 'Other', NO_DISCLOSURE]
 
     # must be overridden
     def requiredFields(self):
-        return ['registration',  'username', 'email', 'accepted_tos', 'date_registered']
+        return ['registration', 'username', 'email', 'accepted_tos', 'date_registered']
 
     # must be overrriden
     def fields(self):
         b = super(User, self)
         return {
-            'registration' : (b.is_in_list(self.REGISTRATION_METHODS),),
-            'username' : (b.is_string,b.is_not_empty,),
-            'email' : (b.is_string, b.is_valid_email, ),
-            'accepted_tos' : (b.is_truthy,),
-            'gender' : (b.is_in_list(self.USER_GENDERS),),
-            'ethnicity' : (b.is_in_list(self.USER_ETHNICITIES),),
-            'native_language' : (b.is_in_list(self.USER_NATIVE_LANGUAGES),),
-            'date_registered' : (b.is_date_string,),
-            'last_sign_in' : (b.is_date_string,),
-            'courses' : (b.is_list,),
-            'departments' : (b.is_list,),
-            'created_surveys' : (b.is_list,),
-            'unanswered_surveys' : (b.is_list,),
-            'answered_surveys' : (b.is_list,),
-            'answers' : (b.is_list,),
+            'registration': (b.is_in_list(self.REGISTRATION_METHODS),),
+            'username': (b.is_string, b.is_not_empty,),
+            'email': (b.is_string, b.is_valid_email, ),
+            'accepted_tos': (b.is_truthy,),
+            'gender': (b.is_in_list(self.USER_GENDERS),),
+            'ethnicity': (b.is_in_list(self.USER_ETHNICITIES),),
+            'native_language': (b.is_in_list(self.USER_NATIVE_LANGUAGES),),
+            'date_registered': (b.is_timestamp,),
+            'last_sign_in': (b.is_timestamp,),
+            'courses': (b.is_list,),
+            'departments': (b.is_list,),
+            'created_surveys': (b.is_list,),
+            'unanswered_surveys': (b.is_list,),
+            'answered_surveys': (b.is_list,),
+            'answers': (b.is_list,),
         }
 
     # returns default user data, that can be overwritten. Good for templating a new user
+    # str(datetime.fromtimestamp(time.time()))
     def default(self):
         return {
-            'registration' : self.REGISTRATION_TESTING,
-            'username' : '',
-            'email' : '',
-            'accepted_tos' : False,
-            'gender' : self.USER_GENDERS[-1],
-            'ethnicity' : self.USER_ETHNICITIES[-1],
-            'native_language' : self.USER_NATIVE_LANGUAGES[-1],
-            'date_registered' : time.strftime('%a %b %d %H:%M:%S %Z %Y'),
-            'last_sign_in' : time.strftime('%a %b %d %H:%M:%S %Z %Y'),
-            'courses' : [],
-            'departments' : [],
-            'unanswered_surveys' : [],
-            'answered_surveys' : [],
-            'created_surveys' : [],
-            'answers' : [],
+            'registration': self.REGISTRATION_TESTING,
+            'username': '',
+            'email': '',
+            'accepted_tos': False,
+            'gender': self.USER_GENDERS[-1],
+            'ethnicity': self.USER_ETHNICITIES[-1],
+            'native_language': self.USER_NATIVE_LANGUAGES[-1],
+            'date_registered': time.time(),
+            'last_sign_in': time.time(),
+            'courses': [],
+            'departments': [],
+            'unanswered_surveys': [],
+            'answered_surveys': [],
+            'created_surveys': [],
+            'answers': [],
         }
 
-    def authenticate_test_user(self,username,password):
+    def authenticate_test_user(self, username, password):
         return password == self.TESTING_PASSWORD
 
-    # Given user_id and possible password, lookup how to authenticate the user
-    # and attempt to authenticate the user
-    # returns True / False whether the authentication is successful
     def authenticate(self, user_id, password):
+        """
+        Given user_id and possible password, lookup how to authenticate the user
+        and then attempt to authenticate the user with their credentials
+        returns True / False whether the authentication is successful
+        """
         user = self.get_item(user_id)
         username = user['username']
         registration = user['registration']
         return {
-            self.REGISTRATION_TESTING : self.authenticate_test_user,
-            self.REGISTRATION_CULDAP  : culdapauth.auth_user_ldap
+            self.REGISTRATION_TESTING: self.authenticate_test_user,
+            self.REGISTRATION_CULDAP: culdapauth.auth_user_ldap
         }[registration](username, password)

--- a/src/server.py
+++ b/src/server.py
@@ -22,6 +22,7 @@ from tornado.concurrent import Future, chain_future
 from tornado.options import define, options
 import time
 
+
 def main():
     initialize_db()
     tornado.options.parse_command_line()
@@ -30,7 +31,8 @@ def main():
     print("Listening for connections on localhost:{0}".format(options.port))
     tornado.ioloop.IOLoop.instance().start()
 
-def initialize_db(db = options.database_name):
+
+def initialize_db(db=options.database_name):
     """
     Initializes a database for use in the project with a specified name
     Specified name defaults to options.database_name
@@ -40,10 +42,10 @@ def initialize_db(db = options.database_name):
         conn = r.connect(host=options.database_host, port=options.database_port)
         BaseModel.DB = db
         BaseModel.conn = conn
-        print("Creating database '{0}'".format(db))
+        logging.info("Creating database '{0}'".format(db))
         r.db_create(db).run(conn)
     except r.errors.ReqlOpFailedError as e:
-        print(e.message)
+        logging.error(e.message)
     except Exception as e:
         logging.error(e.message)
     print('Initializing tables')
@@ -57,17 +59,19 @@ def initialize_db(db = options.database_name):
     User().init(db, conn)
     Response().init(db, conn)
 
+
 def bootstrap_data(user_id):
     initialize_db()
     user_data = User().get_item(user_id)
     if user_data is None:
-        print("user_id {0} does not correspond to a valid user in the database!".format(user_id))
+        logging.error("user_id {0} does not correspond to a valid user in the database!".format(user_id))
         return
     course_id = Course().create_generic_item()
     Course().subscribe_user(user_id, course_id)
     survey_id = Survey().create_generic_item(user_id, course_id)
-    print('survey id:\n'+survey_id)
+    logging.info('survey id:\n' + survey_id)
     return
+
 
 def wipe_data(user_id):
     """
@@ -78,13 +82,13 @@ def wipe_data(user_id):
     initialize_db()
     user_data = User().get_item(user_id)
     if user_data is None:
-        print("user_id {0} does not correspond to a valid user in the database!".format(user_id))
+        logging.error("user_id {0} does not correspond to a valid user in the database!".format(user_id))
         return
     user_data['courses'] = []
     user_data['created_surveys'] = []
     user_data['unanswered_surveys'] = []
     update_response = User().update_item(user_id, user_data)
-    print(update_response)
+    logging.info(update_response)
     return
 
 if __name__ == "__main__":

--- a/src/test/test_basemodel.py
+++ b/src/test/test_basemodel.py
@@ -49,6 +49,11 @@ class TestBaseModel(tornado.testing.AsyncHTTPTestCase):
         MockModel().init(BaseModel.DB, BaseModel.conn)
         return
 
+    def setup():
+        mock_data = {}
+        mock_id = ""
+        mock_x = 0
+
     def get_app(self):
         return application
 
@@ -348,10 +353,42 @@ class TestBaseModel(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual(len(verified), 0)
 
     def test_get_item(self):
-        pass
+        mock_data = MockModel().default()
+        mock_data['x'] = time.time()
+        mock_id = MockModel().create_item(mock_data)
+        item = MockModel().get_item(mock_id)
+        self.assertEqual(item['a'], mock_data['a'])
+        self.assertEqual(item['b'], mock_data['b'])
+        self.assertEqual(item['c'], mock_data['c'])
+        self.assertEqual(item['x'], mock_data['x'])
+        self.assertEqual(item['id'], mock_id)
 
-    def test_find(self):
-        pass
+    def test_find_item(self):
+        mock_data = MockModel().default()
+        mock_time = time.time()
+        mock_data['x'] = mock_time
+        mock_id = MockModel().create_item(mock_data)
+        found = MockModel().find_item({'x': (mock_time - 10)})
+        self.assertEqual(len(found), 0)
+        found = MockModel().find_item({'x': (mock_time)})
+        self.assertEqual(len(found), 1)
+        item = found[0]
+        self.assertEqual(item['a'], mock_data['a'])
+        self.assertEqual(item['b'], mock_data['b'])
+        self.assertEqual(item['c'], mock_data['c'])
+        self.assertEqual(item['x'], mock_data['x'])
+        self.assertEqual(item['id'], mock_id)
+
+    def test_delete_item(self):
+        mock_data = MockModel().default()
+        mock_time = time.time()
+        mock_data['x'] = mock_time
+        mock_id = MockModel().create_item(mock_data)
+        item = MockModel().get_item(mock_id)
+        self.assertIsNotNone(item)
+        MockModel().delete_item(mock_id)
+        item = MockModel().get_item(mock_id)
+        self.assertIsNone(item)
 
     def test_create_item(self):
         mock_data = MockModel().default()
@@ -360,6 +397,10 @@ class TestBaseModel(tornado.testing.AsyncHTTPTestCase):
         mock_data['x'] = time.time()
         mock_id = MockModel().create_item(mock_data)
         self.assertIsNotNone(mock_id)
+
+    def teardown():
+        if (mock_id is not None) or (mock_id is not ""):
+            MockModel.delete_item(mock_id)
 
     def tearDownClass():
         logging.disable(logging.NOTSET)

--- a/src/test/test_handlers.py
+++ b/src/test/test_handlers.py
@@ -7,6 +7,7 @@ from handlers.survey_handler import Response, Surveys
 from config.config import application
 from setup import Setup
 
+
 class TestHandlers(tornado.testing.AsyncHTTPTestCase):
     def setUpClass():
         return

--- a/src/test/test_handlers.py
+++ b/src/test/test_handlers.py
@@ -2,6 +2,7 @@ import unittest
 import tornado.testing
 import tornado.web
 import config.config
+import logging
 from handlers.survey_handler import ResponseHandler, SurveyHandler
 from config.config import application
 from setup import Setup
@@ -9,6 +10,7 @@ from server import initialize_db
 
 class TestHandlers(tornado.testing.AsyncHTTPTestCase):
     def setUpClass():
+        logging.disable(logging.CRITICAL)
         initialize_db(db='test')
 
     def get_app(self):
@@ -21,6 +23,9 @@ class TestHandlers(tornado.testing.AsyncHTTPTestCase):
     def test_dashboard(self):
         response = self.fetch('/dashboard')
         self.assertEqual(response.code, 200)
+
+    def tearDownClass():
+        logging.disable(logging.NOTSET)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/test_services.py
+++ b/src/test/test_services.py
@@ -8,6 +8,7 @@ from handlers.survey_handler import Response, Surveys
 from config.config import application
 from setup import Setup
 
+
 class TestServices(tornado.testing.AsyncHTTPTestCase):
 
     def setUpClass():

--- a/src/test/test_services.py
+++ b/src/test/test_services.py
@@ -8,11 +8,13 @@ from handlers.survey_handler import ResponseHandler, SurveyHandler
 from config.config import application
 from setup import Setup
 from server import initialize_db
+import logging
 
 
 class TestServices(tornado.testing.AsyncHTTPTestCase):
 
     def setUpClass():
+        logging.disable(logging.CRITICAL)
         initialize_db(db='test')
 
     def get_app(self):
@@ -33,6 +35,9 @@ class TestServices(tornado.testing.AsyncHTTPTestCase):
             method='POST',
             body='{"survey": "response"}')
         self.assertEqual(response.code, 200)
+
+    def tearDownClass():
+        logging.disable(logging.NOTSET)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/test_users.py
+++ b/src/test/test_users.py
@@ -10,6 +10,7 @@ from handlers.survey_handler import ResponseHandler, SurveyHandler
 from config.config import application
 from setup import Setup
 from server import initialize_db
+import logging
 
 
 class TestUser(tornado.testing.AsyncHTTPTestCase):
@@ -18,6 +19,7 @@ class TestUser(tornado.testing.AsyncHTTPTestCase):
     username = None
 
     def setUpClass():
+        logging.disable(logging.CRITICAL)
         initialize_db(db='test')
         # Designates Basemodel to use the test database
         BaseModel.DB = 'test'
@@ -59,6 +61,7 @@ class TestUser(tornado.testing.AsyncHTTPTestCase):
 
     def tearDownClass():
         x = User().delete_item(TestUser.user_id)
+        logging.disable(logging.NOTSET)
 
 
 if __name__ == '__main__':

--- a/src/test/test_users.py
+++ b/src/test/test_users.py
@@ -10,6 +10,7 @@ from handlers.survey_handler import Response, Surveys
 from config.config import application
 from setup import Setup
 
+
 class TestUser(tornado.testing.AsyncHTTPTestCase):
     user_data = {}
     user_id = None
@@ -36,13 +37,13 @@ class TestUser(tornado.testing.AsyncHTTPTestCase):
     def test_testing_authentication(self):
         self.assertEqual(TestUser.user_data['registration'], User().REGISTRATION_TESTING)
         good_auth = User().authenticate(TestUser.user_id, User().TESTING_PASSWORD)
-        bad_auth  = User().authenticate(TestUser.user_id,'wrong password')
+        bad_auth = User().authenticate(TestUser.user_id, 'wrong password')
         self.assertTrue(good_auth)
         self.assertFalse(bad_auth)
 
     def test_verify_valid_user(self):
         verify = User().verify(TestUser.user_data)
-        self.assertEqual(verify,[])
+        self.assertEqual(verify, [])
 
     def test_verify_invalid_user(self):
         verify = User().verify(User().default())


### PR DESCRIPTION
- Cleanup of a number of classes and code with pep8 compliance.
- Baemodel under test! :tada: 
- refactored a few variable names (`find` -> `find_item`)
- `schema_strict` method for models to demand strict schema design in database compliance
- changed a few existing tests to not yell logging messages

You too can pep8 compliance with atom and the [linter-pep8 plugin](https://atom.io/packages/linter-pep8)!
