### PR TITLE
reformatted user info for majors, minors, and primary affiliation

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -42,7 +42,7 @@ class User(BaseModel):
             'answered_surveys': (b.is_list,),
             'survey_responses': (b.is_list,),
             'answers': (b.is_list,),
-            'primary_affiliation': (b.is_list,),
+            'primary_affiliation': (b.is_string,),
         }
 
     # returns default user data, that can be overwritten. Good for templating a new user

--- a/models/user.py
+++ b/models/user.py
@@ -66,7 +66,7 @@ class User(BaseModel):
             'created_surveys': [],
             'survey_responses': [],
             'answers': [],
-            'primary_affiliation': [],
+            'primary_affiliation': '',
         }
 
     def create_generic_item(self):

--- a/static/javascripts/components/profile.jsx
+++ b/static/javascripts/components/profile.jsx
@@ -1,11 +1,89 @@
 var ProfilePage = React.createClass({
+getInitialState: function(){
+    var departments = '';
+    var courses = '';
+    var courses_taught = '';
+    var status = '';
+    
+    
+    if(user_data[0].departments.length == 0 || user_data[0].departments == ['']){
+        console.log('default');
+        departments = 'Not enrolled into any departments';
+    }
+    else{
+        for(var i = 0; i < user_data[0].departments.length; i++){
+            departments += user_data[0].departments[i];
+            if(i < user_data[0].departments.length-1){
+                console.log("new line");
+                departments += "\n";
+            }
+            console.log("Departments state: " + departments);
+        }
+    }
+    
+    if(user_data[0].primary_affiliation[0] == "Student"){
+        if(user_data[0].status){
+            status = user_data[0].status;
+        }
+        else{
+            status = "Did not specify academic year";
+        }
+        if(user_data[0].courses.length == 0 || user_data[0].courses == ['']){
+            courses = 'Not enrolled into any courses';
+        }
+        else{
+            for(var i = 0; i < user_data[0].courses.length; i++){
+                courses += user_data[0].courses[i];
+                if(i < user_data[0].courses.length-1){
+                    console.log("new line");
+                    courses += "\n";
+                }
+                console.log("Courses state: " + courses);
+            }
+        }
+    }
+    
+    else if(user_data[0].primary_affiliation[0] == "Faculty"){
+        if(user_data[0].courses_taught.length == 0 || user_data[0].courses_taught == ['']){
+            courses_taught = 'Not enrolled into any departments';
+        }
+        else{
+            for(var i = 0; i < user_data[0].courses_taught.length; i++){
+                courses_taught += user_data[0].courses_taught[i];
+                if(i < user_data[0].courses_taught.length-1){
+                    courses_taught += "\n";
+                }
+                console.log("Courses taught state: " + courses_taught);
+            }
+        }
+    }
+    return{
+    departments: departments,
+    courses: courses,
+    courses_taught: courses_taught,
+    status: status,
+    }
+},
+
     render: function(){
     console.log(user_data)
     return(
-        <div>
-        <body>
-        {user_data[0].gender}
-        </body>
+        <div className="mdl-card mdl-shadow--2dp">
+            <div className="mdl-card__title mdl-color--primary">
+                <h2 className="mdl-card__title-text">User Info</h2>
+            </div>
+            <div className="mdl-card__supporting-text">
+            Username: {user_data[0].username} <br/>
+            User Type: {user_data[0].primary_affiliation[0]} <br/>
+            Email: {user_data[0].email} <br/>
+            Birth Date: {user_data[0].dob} <br/>
+            Gender: {user_data[0].gender} <br/>
+            Ethnicity: {user_data[0].ethnicity} <br/>
+            Native Language: {user_data[0].native_language} <br/>
+            Status: {this.state.status} <br/>
+            Courses Enrolled: {this.state.courses} <br/>
+            Departments: {this.state.departments} <br/>
+            </div>
         </div>
     );
     }

--- a/static/javascripts/components/profile.jsx
+++ b/static/javascripts/components/profile.jsx
@@ -74,7 +74,7 @@ getInitialState: function(){
             </div>
             <div className="mdl-card__supporting-text">
             Username: {user_data[0].username} <br/>
-            User Type: {user_data[0].primary_affiliation[0]} <br/>
+            User Type: {user_data[0].primary_affiliation} <br/>
             Email: {user_data[0].email} <br/>
             Birth Date: {user_data[0].dob} <br/>
             Gender: {user_data[0].gender} <br/>

--- a/static/javascripts/components/profile.jsx
+++ b/static/javascripts/components/profile.jsx
@@ -21,7 +21,7 @@ getInitialState: function(){
         }
     }
     
-    if(user_data[0].primary_affiliation[0] == "Student"){
+    if(user_data[0].primary_affiliation == "Student"){
         if(user_data[0].status){
             status = user_data[0].status;
         }

--- a/test/test_survey_response_handler.py
+++ b/test/test_survey_response_handler.py
@@ -14,7 +14,7 @@ from models.survey_response import SurveyResponse
 import rethinkdb as r
 from handlers.base_handler import BaseHandler
 import logging
-import mock
+from unittest import mock
 
 
 class TestResponseHandler(BaseAsyncTest):


### PR DESCRIPTION
I wanted to reformat how majors, minors, and your primary affiliation was being stored in the db because it didn't make sense the way it was (inconsistent). I don't see the advantages of having 4 separate fields for majors, 2 separate fields for minors, and a list that holds one thing for your primary affiliation. What do you guys think @untra @nicot @sungbae ?
