### PR TITLE
removed pie from multiple choice, 127 characters fix

### DIFF
--- a/models/basemodel.py
+++ b/models/basemodel.py
@@ -79,6 +79,10 @@ class BaseModel:
             assert r.db(self.DB).table(table).get(data).run(self.conn) is not None, "id '{0}' does not exist in table {1}".format(data, table)
         return _exists
 
+    def is_id(self, data):
+        self.is_string(data)
+        assert (len(data) < 127), "id '{0}' must be 127 characters or fewer".format(data)
+
     def is_none(self, data):
         assert data is None, "Must be empty"
 
@@ -387,7 +391,9 @@ class BaseModel:
     def verify(self, data, skipRequiredFields=False, skipStrictSchema=False):
         requiredFields = [] if skipRequiredFields else self.requiredFields()
         strictSchema = False if skipStrictSchema else self.strictSchema()
-        return list(BaseModel.check_data(data, self.fields(), requiredFields, strictSchema))
+        fields = self.fields()
+        fields.update({'id': (self.is_id, )})
+        return list(BaseModel.check_data(data, fields, requiredFields, strictSchema))
 
     def get_all(self):
         table = self.__class__.__name__

--- a/models/survey.py
+++ b/models/survey.py
@@ -155,9 +155,9 @@ class Survey(BaseModel):
     def get_formatted_results(self, survey_id):
         results = self.get_results(survey_id)
 
-        def get_pie_data(question_data):
+        def get_pie_data(question_data, question):
             return r.branch(
-                (r.expr(question_data['response_format'] == Question().RESPONSE_MULTIPLE_CHOICE) | (question_data['response_format'] == Question().RESPONSE_TRUE_OR_FALSE)),
+                (r.expr(question_data['response_format'] == Question().RESPONSE_TRUE_OR_FALSE)),
                 question[1].group(lambda r: r).count().ungroup().map(
                     lambda gr: {
                         'name': gr['group'].coerce_to('string'),
@@ -167,8 +167,8 @@ class Survey(BaseModel):
                 []
             )
 
-        def get_bar_data(question_data):
-            r.branch(
+        def get_bar_data(question_data, question):
+            return r.branch(
                 (r.expr(question_data['response_format'] == Question().RESPONSE_MULTIPLE_CHOICE) | (question_data['response_format'] == Question().RESPONSE_RATING)),
                 r.branch(
                     (question_data['response_format'] == Question().RESPONSE_MULTIPLE_CHOICE),
@@ -191,9 +191,9 @@ class Survey(BaseModel):
                     'results': question[1],
                     'total_responses': question[1].count(),
                     'pie_data': r.db(self.DB).table('Question').get(question[0]).do(
-                        lambda question_data: get_pie_data(question_data)),
+                        lambda question_data: get_pie_data(question_data, question)),
                     'bar_data': r.db(self.DB).table('Question').get(question[0]).do(
-                        lambda question_data: get_bar_data(question_data))
+                        lambda question_data: get_bar_data(question_data, question))
                 }))
             ).run(self.conn)
             return formatted_results

--- a/test/test_basemodel.py
+++ b/test/test_basemodel.py
@@ -37,7 +37,7 @@ class TestBaseModel(BaseAsyncTest):
     mock_x = 0
 
     def setUpClass():
-        # logging.disable(logging.CRITICAL)
+        logging.disable(logging.CRITICAL)
         # Initializes Mockmodel Table
         MockModel().init(BaseAsyncTest.database_name, BaseAsyncTest.conn)
         return

--- a/test/test_survey_results.py
+++ b/test/test_survey_results.py
@@ -124,6 +124,7 @@ class TestSurveyResults(BaseAsyncTest):
         return
 
     def _test_formatted_response_rating(self, formatted_result_data):
+        logging.info(formatted_result_data)
         bar_data = formatted_result_data['bar_data']
         series_data = bar_data['series'][0]
         self.assertNotEqual(bar_data, [])
@@ -141,7 +142,7 @@ class TestSurveyResults(BaseAsyncTest):
 
     def _test_formatted_response_multiple_choice(self, formatted_result_data):
         self.assertNotEqual(formatted_result_data['bar_data'], [])
-        self.assertNotEqual(formatted_result_data['pie_data'], [])
+        self.assertEqual(formatted_result_data['pie_data'], [])
         return
 
     def respond_to_surveys(self):


### PR DESCRIPTION
- This removes pie data from being given for  on multiple choice questions
- This adds that fix for ids being longer than 127 characters (the bug @Bradyta found on monday)
